### PR TITLE
Return empty string in case of error

### DIFF
--- a/ch02/cryptoRand.go
+++ b/ch02/cryptoRand.go
@@ -20,7 +20,10 @@ func generateBytes(n int64) ([]byte, error) {
 
 func generatePass(s int64) (string, error) {
 	b, err := generateBytes(s)
-	return base64.URLEncoding.EncodeToString(b), err
+	if err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.EncodeToString(b), nil
 }
 
 func main() {


### PR DESCRIPTION
It's not considered a good practice to return the value when err is not nil. In this case since the error comes from the previous function call, it's better to return it without the string value since it will be handled and main.